### PR TITLE
fix 'valet status' and 'valet stop'

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -104,4 +104,17 @@ class PhpFpm
             throw new DomainException('Unable to find php-fpm config.');
         }
     }
+
+    public function getFpmService()
+    {
+        if ($this->linux->linkedPhp() === get_config('php-latest')) {
+            return get_config('fpm-service');
+        } elseif ($this->linux->linkedPhp() === get_config('php-56')) {
+            return get_config('fpm56-service');
+        } elseif ($this->linux->linkedPhp() === get_config('php-55')) {
+            return get_config('fpm55-service');
+        } else {
+            throw new DomainException('Unable to find php fpm service.');
+        }
+    }
 }

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -2,8 +2,10 @@
 
 namespace Valet;
 
+use Exception;
 use DomainException;
 use Symfony\Component\Process\Process;
+use Valet\Contracts\LinuxContract;
 
 class PhpFpm
 {
@@ -31,9 +33,9 @@ class PhpFpm
      */
     public function install()
     {
-        if (!$this->linux->installed(get_config('php-latest')) &&
-            !$this->linux->installed(get_config('php-56')) &&
-            !$this->linux->installed(get_config('php-55'))) {
+        if (! $this->linux->installed(get_config('php-latest')) &&
+            ! $this->linux->installed(get_config('php-56')) &&
+            ! $this->linux->installed(get_config('php-55'))) {
             $this->linux->ensureInstalled(get_config('php-latest'));
         }
 
@@ -53,8 +55,8 @@ class PhpFpm
     {
         $contents = $this->files->get($this->fpmConfigPath());
 
-        $contents = preg_replace('/^user = .+$/m', 'user = ' . user(), $contents);
-        $contents = preg_replace('/^listen.owner = .+$/m', 'listen.owner = ' . user(), $contents);
+        $contents = preg_replace('/^user = .+$/m', 'user = '.user(), $contents);
+        $contents = preg_replace('/^listen.owner = .+$/m', 'listen.owner = '.user(), $contents);
 
         $this->files->put($this->fpmConfigPath(), $contents);
     }
@@ -81,7 +83,7 @@ class PhpFpm
         $this->linux->stopService([
             get_config('fpm55-service'),
             get_config('fpm56-service'),
-            get_config('fpm-service'),
+            get_config('fpm-service')
         ]);
     }
 

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -2,10 +2,8 @@
 
 namespace Valet;
 
-use Exception;
 use DomainException;
 use Symfony\Component\Process\Process;
-use Valet\Contracts\LinuxContract;
 
 class PhpFpm
 {
@@ -33,9 +31,9 @@ class PhpFpm
      */
     public function install()
     {
-        if (! $this->linux->installed(get_config('php-latest')) &&
-            ! $this->linux->installed(get_config('php-56')) &&
-            ! $this->linux->installed(get_config('php-55'))) {
+        if (!$this->linux->installed(get_config('php-latest')) &&
+            !$this->linux->installed(get_config('php-56')) &&
+            !$this->linux->installed(get_config('php-55'))) {
             $this->linux->ensureInstalled(get_config('php-latest'));
         }
 
@@ -55,8 +53,8 @@ class PhpFpm
     {
         $contents = $this->files->get($this->fpmConfigPath());
 
-        $contents = preg_replace('/^user = .+$/m', 'user = '.user(), $contents);
-        $contents = preg_replace('/^listen.owner = .+$/m', 'listen.owner = '.user(), $contents);
+        $contents = preg_replace('/^user = .+$/m', 'user = ' . user(), $contents);
+        $contents = preg_replace('/^listen.owner = .+$/m', 'listen.owner = ' . user(), $contents);
 
         $this->files->put($this->fpmConfigPath(), $contents);
     }
@@ -80,11 +78,11 @@ class PhpFpm
      */
     public function stop()
     {
-        $this->linux->stopService(
+        $this->linux->stopService([
             get_config('fpm55-service'),
             get_config('fpm56-service'),
-            get_config('fpm-service')
-        );
+            get_config('fpm-service'),
+        ]);
     }
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -94,7 +94,8 @@ $app->command('forget', function () {
  * Remove the current working directory to the paths configuration.
  */
 $app->command('status', function () {
-    passthru('systemctl status caddy.service php7.0-fpm.service');
+    $phpFpm =  PhpFpm::getFpmService();
+    passthru('systemctl status caddy.service '.$phpFpm.'.service');
 })->descriptions('View Valet service status');
 
 /**


### PR DESCRIPTION
valet status will not check for what is the right php-fpm service instead of hard coding php7.0-fpm.service,

fix valet stop for it will only get the first parameter config, putting all the parameters to array will fix it
