### PR TITLE
Check /etc/issue to find Arch string when running custom kernel

### DIFF
--- a/cli/Valet/Linux.php
+++ b/cli/Valet/Linux.php
@@ -6,7 +6,8 @@ use Valet\Contracts\LinuxContract;
 
 class Linux implements LinuxContract
 {
-    public $cli, $files;
+    public $cli;
+    public $files;
     protected $distribution;
 
     /**

--- a/cli/Valet/Linux.php
+++ b/cli/Valet/Linux.php
@@ -28,6 +28,20 @@ class Linux implements LinuxContract
     {
         $match = [];
         preg_match('/.*-(\w*)/i', strtolower(php_uname('r')), $match);
+        /*
+         * Using a custom kernel on Arch? uname may not have Arch identifier.
+         * Check /etc/issue as a fallback.
+         */
+        if (is_file('/etc/issue') && $match != 'ubuntu' && $match != 'manjaro') {
+            // get contents of /etc/issue into a string
+            $filename = '/etc/issue';
+            $handle = fopen($filename, 'r');
+            $contents = fread($handle, filesize($filename));
+            fclose($handle);
+            if (preg_match('/^Arch/', $contents) == true) {
+                $match[1] = 'arch';
+            }
+        }
         switch ($match[1]) {
             case 'manjaro':
             case 'arch':


### PR DESCRIPTION
Valet fails to default case ubuntu when running the popular mainline kernel in Arch.  Uname can't be used to regex for Arch in this case.  Use /etc/issue.  If we don't do something, valet won't be able to install.  This allows valet to install when running custom kernels on Arch.
