### PR TITLE
remove .valet from retval

### DIFF
--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -148,6 +148,6 @@ class DnsMasq
      */
     public function customConfigPath()
     {
-        return VALET_HOME_PATH.'/.valet/dnsmasq.conf';
+        return VALET_HOME_PATH.'/dnsmasq.conf';
     }
 }

--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -4,8 +4,9 @@ namespace Valet;
 
 class DnsMasq
 {
-    public $linux, $cli, $files;
-
+    public $linux;
+    public $cli;
+    public $files;
     public $configPath = '/etc/dnsmasq.conf';
     public $exampleConfigPath;
 


### PR DESCRIPTION
valet install fails on dnsmasq.conf copy because it tries to copy the dnsmasq.conf file to .valet/.valet/dnsmasq.conf
