### PR TITLE
valet uninstall should remove .valet and dnsmasq setting

### DIFF
--- a/cli/Valet/Caddy.php
+++ b/cli/Valet/Caddy.php
@@ -136,7 +136,13 @@ class Caddy
         $this->cli->quietly('systemctl disable caddy.service');
 
         $this->files->unlink($this->daemonPath);
-
+        // remove .valet files
+        $files = glob('/home/'.$_SERVER['SUDO_USER'].'/.valet/*'); // get all file names
+        foreach($files as $file){ // iterate files
+            if(is_file($file))
+                unlink($file); // delete file
+        }
+        $this->cli->quietly('sed -i \'/conf-file=\/home\/'.$_SERVER['SUDO_USER'].'\/.valet\/dnsmasq.conf/d\' /etc/dnsmasq.conf');
         $this->cli->quietly('systemctl daemon-reload');
     }
 }

--- a/cli/Valet/Caddy.php
+++ b/cli/Valet/Caddy.php
@@ -136,7 +136,14 @@ class Caddy
         $this->cli->quietly('systemctl disable caddy.service');
 
         $this->files->unlink($this->daemonPath);
-
+        // remove .valet files
+        $files = glob('/home/'.$_SERVER['SUDO_USER'].'/.valet/*'); // get all file names
+        foreach ($files as $file) { // iterate files
+            if (is_file($file)) {
+                unlink($file);
+            } // delete file
+        }
+        $this->cli->quietly('sed -i \'/conf-file=\/home\/'.$_SERVER['SUDO_USER'].'\/.valet\/dnsmasq.conf/d\' /etc/dnsmasq.conf');
         $this->cli->quietly('systemctl daemon-reload');
     }
 }


### PR DESCRIPTION
uninstall cleanup - remove .valet from users directory and remove the conf file specific setting from /etc/dnsmasq.conf
