### PR TITLE
fpm-service and fpm-config changed for mint 18

### DIFF
--- a/config.php
+++ b/config.php
@@ -15,8 +15,8 @@ function get_config($value)
 
         // Latest PHP
         'php-latest'  => 'php',
-        'fpm-service' => 'php-fpm',
-        'fpm-config'  => '/etc/php/php-fpm.d/www.conf',
+        'fpm-service' => 'php7.0-fpm',
+        'fpm-config'  => '/etc/php/7.0/fpm/pool.d/www.conf',
 
         // Caddy/Systemd
         'systemd-caddy'     => '/lib/systemd/system/caddy.service',


### PR DESCRIPTION
mint 18 being downstream from ubuntu 16.04, i dont know if this would work if used on ubuntu 14.x or not
