### PR TITLE
Allow passing parameters to ngrok on valet share

### DIFF
--- a/valet
+++ b/valet
@@ -54,7 +54,7 @@ then
 
     # Fetch Ngrok URL In Background...
     bash "$DIR/cli/scripts/fetch-share-url.sh" &
-    sudo -u $LOGNAME "$DIR/bin/ngrok" http -host-header=rewrite "$HOST.$DOMAIN:80"
+    sudo -u $LOGNAME "$DIR/bin/ngrok" http "$HOST.$DOMAIN:80" -host-header=rewrite ${*:2}
     exit
 
 # Finally, for every other command we will just proxy into the PHP tool


### PR DESCRIPTION
Credits to renedekat (https://github.com/renedekat/valet/pull/1)

This makes it possible to add custom parameters to ngrok. For example:
valet share -region eu
